### PR TITLE
Make it so for a DAG, instead of seeing "Response 1", each Agent/Moderator sees the name of an Agent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ cython_debug/
 /docs/_build/doctrees/using_agents.doctree
 /docs/_build/doctrees/using_moderators.doctree
 /docs/_build/doctrees/using_structures.doctree
+/my_tests.ipynb

--- a/docs/tutorial_4_structures.rst
+++ b/docs/tutorial_4_structures.rst
@@ -361,7 +361,7 @@ So let's take a code block:
         'libertarian': Agent(system_instructions="you are a libertarian", model="gpt-3.5-turbo")
     }
     edges = [('liberal', 'conservative'), ('liberal', 'libertarian'), ('conservative', 'libertarian')]
-    task = "What are your thoughts on the role of government in society?"
+    task = "What are your thoughts on the role of government in society? Answer in 3 words."
     graph = Graph(agents=agents, edges=edges, task=task)
     graph.process()
 

--- a/docs/tutorial_4_structures.rst
+++ b/docs/tutorial_4_structures.rst
@@ -350,9 +350,31 @@ in addition to system instructions.
 
 
 
+In a DAG, each Agent (and the Moderator) sees the responses of previous Agents with their names attached to them.
+So let's take a code block:
 
+.. code-block:: python
 
+    agents = {
+        'liberal': Agent(system_instructions="you are a liberal", model="gpt-3.5-turbo"),
+        'conservative': Agent(system_instructions="you are a conservative", model="gpt-3.5-turbo"),
+        'libertarian': Agent(system_instructions="you are a libertarian", model="gpt-3.5-turbo")
+    }
+    edges = [('liberal', 'conservative'), ('liberal', 'libertarian'), ('conservative', 'libertarian')]
+    task = "What are your thoughts on the role of government in society?"
+    graph = Graph(agents=agents, edges=edges, task=task)
+    graph.process()
 
+The libertarian will see the responses of both the liberal and conservative agents, with their names prefixed.
+
+.. code-block:: text
+
+    liberal: [liberal's response]
+    conservative: [conservative's response]
+
+This makes it clearer which agent said what, especially in complex DAG structures.
+
+If you use the list-of-agents method, the agents will be 'named' "Agent 1", "Agent 2", etc. based on their order in the list.
 
 
 Tracing what is going on in Structures

--- a/plurals/deliberation.py
+++ b/plurals/deliberation.py
@@ -248,17 +248,18 @@ class Moderator(Agent):
         self.system_instructions = self.generate_system_instructions(task, max_tries)
         return self.system_instructions
 
-    def _moderate_responses(self, responses: List[str]) -> str:
+    def _moderate_responses(self, responses: List[str], agent_names: Optional[List[str]] = None) -> str:
         """
         Combine responses using the moderator persona and instructions.
 
         Args:
             responses (List[str]): List of responses from agents to combine.
+            agent_names (Optional[List[str]]): Optional list of agent names corresponding to responses.
 
         Returns:
             str: A combined response based on the moderator's instructions
         """
-        combined_responses_str = format_previous_responses(responses)
+        combined_responses_str = format_previous_responses(responses, agent_names=agent_names)
         self.combination_instructions = SmartString(
             self.combination_instructions
         ).format(
@@ -900,12 +901,17 @@ class Graph(AbstractStructure):
 
         # Process agents according to topological order
         response_dict = {}
+
+        agent_to_name = self._create_agent_name_mapping()
         for agent in topological_order:
             # Gather responses from all predecessors to form the input for the current agent
-            previous_responses = [
-                response_dict[pred] for pred in self.agents if agent in self.graph[pred]
-            ]
-            previous_responses_str = format_previous_responses(previous_responses)
+            predecessors = [pred for pred in self.agents if agent in self.graph[pred]]
+            previous_responses = [response_dict[pred] for pred in predecessors]
+            previous_agent_names = [agent_to_name[pred] for pred in predecessors]
+            previous_responses_str = format_previous_responses(
+                previous_responses,
+                agent_names=previous_agent_names
+            )
             response = agent.process(previous_responses=previous_responses_str)
             response_dict[agent] = response
             self.responses.append(response)
@@ -913,13 +919,41 @@ class Graph(AbstractStructure):
         # Handle the moderator if present
         if self.moderated and self.moderator:
             original_task = self.agents[0].original_task_description
+            # Get all agent names in the order of responses
+            all_agent_names = [agent_to_name[agent] for agent in topological_order]
             moderated_response = self.moderator._moderate_responses(
-                list(response_dict.values())
+                list(response_dict.values()),
+                agent_names=all_agent_names
             )
             self.responses.append(moderated_response)
             self.final_response = moderated_response
         self.final_response = self.responses[-1]
         return self.final_response
+
+    def _create_agent_name_mapping(self) -> Dict[Agent, str]:
+        """
+        Create a mapping from Agent objects to their names.
+
+        Returns:
+            Dict[Agent, str]: Mapping of agents to display names
+        """
+        agent_to_name = {}
+
+        # If original_agents was a dict (Method 2), use those names
+        if isinstance(self.original_agents, dict):
+            name_to_agent = {name: agent for name, agent in self.original_agents.items()}
+            for agent in self.agents:
+                # Find the corresponding name
+                for name, orig_agent in name_to_agent.items():
+                    if orig_agent is agent:
+                        agent_to_name[agent] = name
+                        break
+        else:
+            # Method 1: Use simple Agent numbering
+            for idx, agent in enumerate(self.agents):
+                agent_to_name[agent] = f"Agent {idx}"
+
+        return agent_to_name
 
     @staticmethod
     def _validate_input_format(agents, edges):
@@ -965,3 +999,5 @@ class Graph(AbstractStructure):
                     raise ValueError(
                         "Agent names in edges must be keys in the agent dictionary."
                     )
+
+

--- a/plurals/deliberation.py
+++ b/plurals/deliberation.py
@@ -785,6 +785,50 @@ class Graph(AbstractStructure):
             task = "What are your thoughts on the role of government in society?"
             graph = Graph(agents=agents, edges=edges, task=task)
             graph.process()
+
+    **Note:**
+
+    In a DAG, each Agent (and the Moderator) sees the responses of previous Agents with their names attached to them.
+    So let's take the code block above:
+
+    .. code-block:: python
+
+        agents = {
+            'liberal': Agent(system_instructions="you are a liberal", model="gpt-3.5-turbo"),
+            'conservative': Agent(system_instructions="you are a conservative", model="gpt-3.5-turbo"),
+            'libertarian': Agent(system_instructions="you are a libertarian", model="gpt-3.5-turbo")
+        }
+        edges = [('liberal', 'conservative'), ('liberal', 'libertarian'), ('conservative', 'libertarian')]
+        task = "What are your thoughts on the role of government in society?"
+        graph = Graph(agents=agents, edges=edges, task=task)
+        graph.process()
+
+    The libertarian will see the responses of both the liberal and conservative agents, with their names prefixed.
+
+    .. code-block:: text
+
+        liberal: [liberal's response]
+        conservative: [conservative's response]
+
+    This makes it clearer which agent said what, especially in complex DAG structures. Similarly, if a Moderator is present,
+    it will see all responses with agent names:
+
+    .. code-block:: python
+
+        moderator = Moderator(persona='default', model='gpt-4o')
+        graph = Graph(agents=agents, edges=edges, task=task, moderator=moderator)
+        graph.process()
+
+    The moderator will see:
+
+    .. code-block:: text
+
+        liberal: [liberal's response]
+        conservative: [conservative's response]
+        libertarian: [libertarian's response]
+
+    If you use the list-of-agents method, the agents will be 'named' "Agent 1", "Agent 2", etc. based on their order in the list.
+
     """
 
     def __init__(

--- a/plurals/helpers.py
+++ b/plurals/helpers.py
@@ -1,6 +1,6 @@
 import os
 import string
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import pandas as pd
 import yaml
@@ -86,12 +86,13 @@ def load_yaml(file_path: str) -> Dict[str, Any]:
         return yaml.safe_load(file)
 
 
-def format_previous_responses(responses: List[str]) -> str:
+def format_previous_responses(responses: List[str], agent_names: Optional[List[str]] = None) -> str:
     """
     Format the previous responses for inclusion in the next task description.
 
     Args:
         responses (List[str]): A list of previous responses.
+        agent_names (Optional[List[str]]): Optional list of agent names/identifiers corresponding to each response.
 
     Returns:
         str: A formatted string of the previous responses.
@@ -100,14 +101,23 @@ def format_previous_responses(responses: List[str]) -> str:
         >>> responses = ["First response", "Second response"]
         >>> format_previous_responses(responses)
         'Response 0: First response\\nResponse 1: Second response'
+
+        >>> format_previous_responses(responses, agent_names=["Agent A", "Agent B"])
+        'Agent A: First response\\nAgent B: Second response'
     """
     if not responses:
         return ""
     else:
-        resp_list = [
-            "Response {}: {}\n".format(i, responses[i])
-            for i in range(len(responses))
-        ]
+        if agent_names and len(agent_names) == len(responses):
+            resp_list = [
+                "{}: {}\n".format(agent_names[i], responses[i])
+                for i in range(len(responses))
+            ]
+        else:
+            resp_list = [
+                "Response {}: {}\n".format(i, responses[i])
+                for i in range(len(responses))
+            ]
         return "".join(resp_list).strip()
 
 

--- a/plurals/tests.py
+++ b/plurals/tests.py
@@ -1669,7 +1669,7 @@ class TestNetworkStructure(unittest.TestCase):
         expected_agent2_task_description = """Describe the impact of social media on society in 50 words.\nUSE PREVIOUS RESPONSES TO COMPLETE THE TASK
 Here are the previous responses: 
  <start>
- Response 0: Social media has both positive and negative impacts on society.
+ Agent 0: Social media has both positive and negative impacts on society.
  <end>"""
 
         # Assertions

--- a/plurals/tests.py
+++ b/plurals/tests.py
@@ -2394,6 +2394,158 @@ class TestEnsembleOrdering(unittest.TestCase):
             self.assertEqual(ensemble.final_response, 'MOD')
 
 
+class TestGraphAgentNaming(unittest.TestCase):
+    """Test that agent names appear correctly in Graph structure for both agents and moderators"""
+
+    def setUp(self):
+        self.task = "What are your thoughts on government? answer in 1 word only"
+        self.model = "gpt-4o-mini"
+
+    def test_graph_dict_method_agent_names_in_responses(self):
+        """Test that when using dict method, agent names appear in previous_responses for agents"""
+        agents = {
+            'liberal': Agent(system_instructions="you are a liberal", model=self.model),
+            'conservative': Agent(system_instructions="you are a conservative", model=self.model),
+            'libertarian': Agent(system_instructions="you are a libertarian", model=self.model)
+        }
+        edges = [('liberal', 'conservative'), ('liberal', 'libertarian'), ('conservative', 'libertarian')]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+        graph.process()
+
+        # Check that libertarian agent saw named responses
+        libertarian_prompt = agents['libertarian'].prompts[0]['user']
+        self.assertIn('liberal:', libertarian_prompt)
+        self.assertIn('conservative:', libertarian_prompt)
+
+    def test_graph_list_method_agent_names_in_responses(self):
+        """Test that when using list method, agent indices appear in previous_responses for agents"""
+        agents = [
+            Agent(system_instructions="you are a liberal", model=self.model),
+            Agent(system_instructions="you are a conservative", model=self.model),
+            Agent(system_instructions="you are a libertarian", model=self.model)
+        ]
+        edges = [(0, 1), (0, 2), (1, 2)]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+        graph.process()
+
+        # Check that libertarian agent (index 2) saw numbered agent responses
+        libertarian_prompt = agents[2].prompts[0]['user']
+        self.assertIn('Agent 0:', libertarian_prompt)
+        self.assertIn('Agent 1:', libertarian_prompt)
+
+    def test_graph_dict_method_moderator_sees_agent_names(self):
+        """Test that moderator sees agent names when using dict method"""
+        agents = {
+            'liberal': Agent(system_instructions="you are a liberal", model=self.model),
+            'conservative': Agent(system_instructions="you are a conservative", model=self.model),
+        }
+        edges = [('liberal', 'conservative')]
+
+        moderator = Moderator(persona='default', model=self.model)
+        graph = Graph(agents=agents, edges=edges, task=self.task, moderator=moderator)
+        graph.process()
+
+        # Check that moderator saw named responses
+        moderator_prompt = moderator.prompts[0]['user']
+        self.assertIn('liberal:', moderator_prompt)
+        self.assertIn('conservative:', moderator_prompt)
+
+    def test_graph_list_method_moderator_sees_agent_indices(self):
+        """Test that moderator sees agent indices when using list method"""
+        agents = [
+            Agent(system_instructions="you are a liberal", model=self.model),
+            Agent(system_instructions="you are a conservative", model=self.model),
+        ]
+        edges = [(0, 1)]
+
+        moderator = Moderator(persona='default', model=self.model)
+        graph = Graph(agents=agents, edges=edges, task=self.task, moderator=moderator)
+        graph.process()
+
+        # Check that moderator saw numbered agent responses
+        moderator_prompt = moderator.prompts[0]['user']
+        self.assertIn('Agent 0:', moderator_prompt)
+        self.assertIn('Agent 1:', moderator_prompt)
+
+    def test_graph_complex_dag_agent_names(self):
+        """Test agent names in a more complex DAG structure"""
+        agents = {
+            'A': Agent(system_instructions="Agent A", model=self.model),
+            'B': Agent(system_instructions="Agent B", model=self.model),
+            'C': Agent(system_instructions="Agent C", model=self.model),
+            'D': Agent(system_instructions="Agent D", model=self.model),
+        }
+        # A -> B, A -> C, B -> D, C -> D
+        edges = [('A', 'B'), ('A', 'C'), ('B', 'D'), ('C', 'D')]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+        graph.process()
+
+        # Agent D should see responses from B and C
+        agent_d_prompt = agents['D'].prompts[0]['user']
+        self.assertIn('B:', agent_d_prompt)
+        self.assertIn('C:', agent_d_prompt)
+        self.assertNotIn('A:', agent_d_prompt)  # D doesn't directly receive from A
+
+    def test_graph_agent_name_mapping_consistency(self):
+        """Test that agent name mapping is consistent throughout processing"""
+        agents = {
+            'first': Agent(system_instructions="first agent", model=self.model),
+            'second': Agent(system_instructions="second agent", model=self.model),
+            'third': Agent(system_instructions="third agent", model=self.model),
+        }
+        edges = [('first', 'second'), ('second', 'third')]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+
+        # Get the mapping
+        agent_to_name = graph._create_agent_name_mapping()
+
+        # Verify mapping is correct
+        self.assertEqual(agent_to_name[agents['first']], 'first')
+        self.assertEqual(agent_to_name[agents['second']], 'second')
+        self.assertEqual(agent_to_name[agents['third']], 'third')
+        self.assertEqual(len(agent_to_name), 3)
+
+    def test_graph_list_agent_name_mapping_consistency(self):
+        """Test that agent name mapping is consistent for list method"""
+        agents = [
+            Agent(system_instructions="first agent", model=self.model),
+            Agent(system_instructions="second agent", model=self.model),
+            Agent(system_instructions="third agent", model=self.model),
+        ]
+        edges = [(0, 1), (1, 2)]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+
+        # Get the mapping
+        agent_to_name = graph._create_agent_name_mapping()
+
+        # Verify mapping uses indices
+        self.assertEqual(agent_to_name[agents[0]], 'Agent 0')
+        self.assertEqual(agent_to_name[agents[1]], 'Agent 1')
+        self.assertEqual(agent_to_name[agents[2]], 'Agent 2')
+        self.assertEqual(len(agent_to_name), 3)
+
+    def test_graph_no_moderator_agent_names_still_work(self):
+        """Test that agent names work correctly even without a moderator"""
+        agents = {
+            'alice': Agent(system_instructions="alice", model=self.model),
+            'bob': Agent(system_instructions="bob", model=self.model),
+        }
+        edges = [('alice', 'bob')]
+
+        graph = Graph(agents=agents, edges=edges, task=self.task)
+        graph.process()
+
+        # Bob should see Alice's response with name
+        bob_prompt = agents['bob'].prompts[0]['user']
+        self.assertIn('alice:', bob_prompt)
+        self.assertNotIn('Response 0:', bob_prompt)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Goal: Make it so for a DAG, instead of seeing "Response 1", each Agent/Moderator sees the name of an Agent.

Changes:
- Changed `format_previous_responses` to accept Agent names
- Modified `process` function of DAG
- Modified `moderate_responses` function of Moderator

Tests
- Updated old tests to expect new output
- Added new tests to make sure this naming logic is working correctly. Tested the 4 main cases: {with moderator, without moderator} x {list inititalizer, dict initializer}

Docs
- Updated docstring of deliberation to say this change
- Updated structure tutorial to make brief mention of this fact 
